### PR TITLE
#19 - WinForm Blackout Screen Timing Customization + #29 - Saving Profile Names from "Edit"

### DIFF
--- a/HeliosDisplayManagement.Shared/HeliosDisplayManagement.Shared.csproj
+++ b/HeliosDisplayManagement.Shared/HeliosDisplayManagement.Shared.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Appccelerate.StateMachine, Version=4.4.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appccelerate.StateMachine.4.4.0\lib\netstandard1.0\Appccelerate.StateMachine.dll</HintPath>
+    </Reference>
     <Reference Include="EDIDParser, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\EDIDParser.1.2.0.1\lib\net45\EDIDParser.dll</HintPath>
     </Reference>

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -6,12 +6,14 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using System.Diagnostics;
 using WindowsDisplayAPI.DisplayConfig;
 using HeliosDisplayManagement.Shared.Resources;
 using Newtonsoft.Json;
 using NvAPIWrapper.GPU;
 using NvAPIWrapper.Mosaic;
 using NvAPIWrapper.Native.Mosaic;
+using Appccelerate.StateMachine;
 using Path = HeliosDisplayManagement.Shared.Topology.Path;
 
 namespace HeliosDisplayManagement.Shared
@@ -124,6 +126,9 @@ namespace HeliosDisplayManagement.Shared
         }
 
         public Path[] Paths { get; set; } = new Path[0];
+
+        [JsonIgnore]
+        public PassiveStateMachine<States, StateCmd> fsm = _profileStateMachine();
 
         public static string ProfilesPath
         {
@@ -276,12 +281,9 @@ namespace HeliosDisplayManagement.Shared
             return (Name ?? Language.UN_TITLED_PROFILE) + (IsActive ? " " + Language._Active_ : "");
         }
 
-        public bool Apply()
+        private void _applyTopos() 
         {
-            try
-            {
-                Thread.Sleep(2000);
-
+            
                 try
                 {
                     var surroundTopologies =
@@ -314,9 +316,11 @@ namespace HeliosDisplayManagement.Shared
                 {
                     // ignored
                 }
+        }
 
-                Thread.Sleep(18000);
-                var pathInfos = Paths.Select(path => path.ToPathInfo()).Where(info => info != null).ToArray();
+        private void _applyPathInfos() 
+        {
+               var pathInfos = Paths.Select(path => path.ToPathInfo()).Where(info => info != null).ToArray();
 
                 if (!pathInfos.Any())
                 {
@@ -325,7 +329,66 @@ namespace HeliosDisplayManagement.Shared
                 }
 
                 PathInfo.ApplyPathInfos(pathInfos, true, true, true);
+        }
+
+        public enum States 
+        {
+            Idle,
+            SettingTopos,
+            SettingPathInfo
+        }
+        
+        public enum StateCmd 
+        {
+            Begin,
+            Next
+        }
+
+        private PassiveStateMachine<States, StateCmd> _profileStateMachine() 
+        {
+            var fsm = new PassiveStateMachine<States, StateCmd>();
+            fsm.In(States.Idle)
+                .On(StateCmd.Begin)
+                .Goto(States.SettingTopos)
+                .Execute(_applyTopos);
+            
+            fsm.In(States.SettingTopos)
+                .On(StateCmd.Next)
+                .Goto(States.SettingPathInfo)
+                .Execute(_applyPathInfos);
+
+            fsm.In(States.SettingPathInfo)
+                .On(StateCmd.Next)
+                .Goto(States.Idle);
+            
+            return fsm;
+        }
+
+        public bool Apply()
+        {
+            try
+            {
+                var fsm = profileStateMachine();
+                fsm.Initialize(States.Idle);
+                fsm.Start();
+                Debug.Print("Begin profile change");
+                Thread.Sleep(2000);
+                fsm.Fire(StateCmd.Begin);
+
+                Debug.Print("Finished setting topologies");
+                Debug.Print("Sleep");
+                Thread.Sleep(18000);
+                Debug.Print("Awake");
+
+                fsm.Fire(StateCmd.Next);
+ 
+                Debug.Print("Applying pathInfos");
+                Debug.Print("Sleep");
                 Thread.Sleep(10000);
+                Debug.Print("Awake");
+
+                fsm.Fire(StateCmd.Next);
+
                 RefreshActiveStatus();
 
                 return true;

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -111,13 +111,13 @@ namespace HeliosDisplayManagement.Shared
 
         public string Name { get; set; }
 
-        public bool isCustomTimeEnabled { get; set; } = false;
+        public bool IsCustomTimeEnabled { get; set; } 
 
         public int switchTime
         {
             get
             {
-                if (!isCustomTimeEnabled) { return switchTimeDefault; }
+                if (!IsCustomTimeEnabled) { return switchTimeDefault; }
                 return _switchTime;
             }
             set => _switchTime = value;

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -36,6 +36,21 @@ namespace HeliosDisplayManagement.Shared
 
         public string Id { get; set; } = Guid.NewGuid().ToString("B");
 
+        public static int switchTimeDefault = 30;
+
+        public bool isCustomTimeEnabled { get; set; } = false;
+
+        private int _switchTime = switchTimeDefault;
+        public int switchTime
+        {
+            get
+            {
+                if (!isCustomTimeEnabled) return switchTimeDefault;
+                return _switchTime;
+            }
+            set => _switchTime = value;
+        }
+
         [JsonIgnore]
         public bool IsActive
         {

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -117,7 +117,7 @@ namespace HeliosDisplayManagement.Shared
         {
             get
             {
-                if (!isCustomTimeEnabled) return switchTimeDefault;
+                if (!isCustomTimeEnabled) { return switchTimeDefault; }
                 return _switchTime;
             }
             set => _switchTime = value;

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -36,16 +36,16 @@ namespace HeliosDisplayManagement.Shared
 
         public string Id { get; set; } = Guid.NewGuid().ToString("B");
 
-        public static const int switchTimeDefault = 30;
+        public static int switchTimeDefault = 30;
 
-        public bool isCustomTimeEnabled { get; set; };
+        public bool isCustomTimeEnabled { get; set; } = false;
 
         private int _switchTime = switchTimeDefault;
         public int switchTime
         {
             get
             {
-                if (!isCustomTimeEnabled) { return switchTimeDefault; } 
+                if (!isCustomTimeEnabled) return switchTimeDefault;
                 return _switchTime;
             }
             set => _switchTime = value;

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -36,7 +36,7 @@ namespace HeliosDisplayManagement.Shared
 
         public string Id { get; set; } = Guid.NewGuid().ToString("B");
 
-        public static int switchTimeDefault = 30;
+        public static readonly int switchTimeDefault = 30;
 
         public bool isCustomTimeEnabled { get; set; } = false;
 

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -36,16 +36,16 @@ namespace HeliosDisplayManagement.Shared
 
         public string Id { get; set; } = Guid.NewGuid().ToString("B");
 
-        public static int switchTimeDefault = 30;
+        public static const int switchTimeDefault = 30;
 
-        public bool isCustomTimeEnabled { get; set; } = false;
+        public bool isCustomTimeEnabled { get; set; };
 
         private int _switchTime = switchTimeDefault;
         public int switchTime
         {
             get
             {
-                if (!isCustomTimeEnabled) return switchTimeDefault;
+                if (!isCustomTimeEnabled) { return switchTimeDefault; } 
                 return _switchTime;
             }
             set => _switchTime = value;

--- a/HeliosDisplayManagement.Shared/Profile.cs
+++ b/HeliosDisplayManagement.Shared/Profile.cs
@@ -21,6 +21,9 @@ namespace HeliosDisplayManagement.Shared
         private static Profile _currentProfile;
 
         public static Version Version = new Version(2, 0);
+        public static readonly int switchTimeDefault = 30;
+
+        private int _switchTime = switchTimeDefault;
 
         static Profile()
         {
@@ -35,21 +38,6 @@ namespace HeliosDisplayManagement.Shared
         }
 
         public string Id { get; set; } = Guid.NewGuid().ToString("B");
-
-        public static readonly int switchTimeDefault = 30;
-
-        public bool isCustomTimeEnabled { get; set; } = false;
-
-        private int _switchTime = switchTimeDefault;
-        public int switchTime
-        {
-            get
-            {
-                if (!isCustomTimeEnabled) return switchTimeDefault;
-                return _switchTime;
-            }
-            set => _switchTime = value;
-        }
 
         [JsonIgnore]
         public bool IsActive
@@ -122,6 +110,18 @@ namespace HeliosDisplayManagement.Shared
         }
 
         public string Name { get; set; }
+
+        public bool isCustomTimeEnabled { get; set; } = false;
+
+        public int switchTime
+        {
+            get
+            {
+                if (!isCustomTimeEnabled) return switchTimeDefault;
+                return _switchTime;
+            }
+            set => _switchTime = value;
+        }
 
         public Path[] Paths { get; set; } = new Path[0];
 

--- a/HeliosDisplayManagement.Shared/packages.config
+++ b/HeliosDisplayManagement.Shared/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Appccelerate.StateMachine" version="4.4.0" targetFramework="net45" />
   <package id="EDIDParser" version="1.2.0.1" targetFramework="net45" />
   <package id="IconLib.Unofficial" version="0.73.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />

--- a/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
@@ -415,6 +415,7 @@ namespace HeliosDisplayManagement.UIForms
             this.cb_custom_timings.TabIndex = 1;
             this.cb_custom_timings.Text = "Enable Custom Timings";
             this.cb_custom_timings.UseVisualStyleBackColor = true;
+            this.cb_custom_timings.CheckedChanged += new System.EventHandler(this.cb_custom_timings_CheckedChanged);
             // 
             // EditForm
             // 

--- a/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
@@ -36,7 +36,6 @@ namespace HeliosDisplayManagement.UIForms
             this.btn_save = new System.Windows.Forms.Button();
             this.btn_apply = new System.Windows.Forms.Button();
             this.btn_cancel = new System.Windows.Forms.Button();
-            this.dv_profile = new HeliosDisplayManagement.Shared.UserControls.DisplayView();
             this.txt_name = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.lv_monitors = new System.Windows.Forms.ListView();
@@ -65,6 +64,7 @@ namespace HeliosDisplayManagement.UIForms
             this.cb_custom_timings = new System.Windows.Forms.CheckBox();
             this.nud_timing = new System.Windows.Forms.NumericUpDown();
             this.time_set_label = new System.Windows.Forms.Label();
+            this.dv_profile = new HeliosDisplayManagement.Shared.UserControls.DisplayView();
             this.gb_arrangement.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nud_y)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nud_x)).BeginInit();
@@ -107,24 +107,6 @@ namespace HeliosDisplayManagement.UIForms
             this.btn_cancel.TabIndex = 7;
             this.btn_cancel.Text = global::HeliosDisplayManagement.Resources.Language.Cancel;
             this.btn_cancel.UseVisualStyleBackColor = true;
-            // 
-            // dv_profile
-            // 
-            this.dv_profile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.dv_profile.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(174)))), ((int)(((byte)(184)))), ((int)(((byte)(196)))));
-            this.dv_profile.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.dv_profile.Font = new System.Drawing.Font("Consolas", 50F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.dv_profile.ForeColor = System.Drawing.Color.MidnightBlue;
-            this.dv_profile.Location = new System.Drawing.Point(-1, -1);
-            this.dv_profile.Margin = new System.Windows.Forms.Padding(18);
-            this.dv_profile.Name = "dv_profile";
-            this.dv_profile.PaddingX = 100;
-            this.dv_profile.PaddingY = 100;
-            this.dv_profile.Profile = null;
-            this.dv_profile.Size = new System.Drawing.Size(658, 236);
-            this.dv_profile.TabIndex = 2;
             // 
             // txt_name
             // 
@@ -413,7 +395,6 @@ namespace HeliosDisplayManagement.UIForms
             // cb_custom_timings
             // 
             this.cb_custom_timings.AutoSize = true;
-            this.cb_custom_timings.Enabled = false;
             this.cb_custom_timings.Location = new System.Drawing.Point(6, 28);
             this.cb_custom_timings.Name = "cb_custom_timings";
             this.cb_custom_timings.Size = new System.Drawing.Size(136, 17);
@@ -428,6 +409,7 @@ namespace HeliosDisplayManagement.UIForms
             this.nud_timing.Name = "nud_timing";
             this.nud_timing.Size = new System.Drawing.Size(34, 20);
             this.nud_timing.TabIndex = 2;
+            this.nud_timing.ValueChanged += new System.EventHandler(this.nud_timing_ValueChanged);
             // 
             // time_set_label
             // 
@@ -437,6 +419,24 @@ namespace HeliosDisplayManagement.UIForms
             this.time_set_label.Size = new System.Drawing.Size(112, 13);
             this.time_set_label.TabIndex = 3;
             this.time_set_label.Text = "Swap Splash Duration";
+            // 
+            // dv_profile
+            // 
+            this.dv_profile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dv_profile.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(174)))), ((int)(((byte)(184)))), ((int)(((byte)(196)))));
+            this.dv_profile.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.dv_profile.Font = new System.Drawing.Font("Consolas", 50F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.dv_profile.ForeColor = System.Drawing.Color.MidnightBlue;
+            this.dv_profile.Location = new System.Drawing.Point(-1, -1);
+            this.dv_profile.Margin = new System.Windows.Forms.Padding(18);
+            this.dv_profile.Name = "dv_profile";
+            this.dv_profile.PaddingX = 100;
+            this.dv_profile.PaddingY = 100;
+            this.dv_profile.Profile = null;
+            this.dv_profile.Size = new System.Drawing.Size(658, 236);
+            this.dv_profile.TabIndex = 2;
             // 
             // EditForm
             // 

--- a/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
@@ -63,12 +63,15 @@ namespace HeliosDisplayManagement.UIForms
             this.label5 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.cb_custom_timings = new System.Windows.Forms.CheckBox();
+            this.nud_timing = new System.Windows.Forms.NumericUpDown();
+            this.time_set_label = new System.Windows.Forms.Label();
             this.gb_arrangement.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nud_y)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nud_x)).BeginInit();
             this.gb_surround.SuspendLayout();
             this.gb_eyefinity.SuspendLayout();
             this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nud_timing)).BeginInit();
             this.SuspendLayout();
             // 
             // btn_save
@@ -397,6 +400,8 @@ namespace HeliosDisplayManagement.UIForms
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.time_set_label);
+            this.groupBox1.Controls.Add(this.nud_timing);
             this.groupBox1.Controls.Add(this.cb_custom_timings);
             this.groupBox1.Location = new System.Drawing.Point(224, 451);
             this.groupBox1.Name = "groupBox1";
@@ -416,6 +421,22 @@ namespace HeliosDisplayManagement.UIForms
             this.cb_custom_timings.Text = "Enable Custom Timings";
             this.cb_custom_timings.UseVisualStyleBackColor = true;
             this.cb_custom_timings.CheckedChanged += new System.EventHandler(this.cb_custom_timings_CheckedChanged);
+            // 
+            // nud_timing
+            // 
+            this.nud_timing.Location = new System.Drawing.Point(6, 54);
+            this.nud_timing.Name = "nud_timing";
+            this.nud_timing.Size = new System.Drawing.Size(34, 20);
+            this.nud_timing.TabIndex = 2;
+            // 
+            // time_set_label
+            // 
+            this.time_set_label.AutoSize = true;
+            this.time_set_label.Location = new System.Drawing.Point(46, 56);
+            this.time_set_label.Name = "time_set_label";
+            this.time_set_label.Size = new System.Drawing.Size(112, 13);
+            this.time_set_label.TabIndex = 3;
+            this.time_set_label.Text = "Swap Splash Duration";
             // 
             // EditForm
             // 
@@ -454,6 +475,7 @@ namespace HeliosDisplayManagement.UIForms
             this.gb_eyefinity.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nud_timing)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -491,5 +513,7 @@ namespace HeliosDisplayManagement.UIForms
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckBox cb_custom_timings;
+        private System.Windows.Forms.NumericUpDown nud_timing;
+        private System.Windows.Forms.Label time_set_label;
     }
 }

--- a/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
@@ -61,11 +61,14 @@ namespace HeliosDisplayManagement.UIForms
             this.gb_eyefinity = new System.Windows.Forms.GroupBox();
             this.label10 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.cb_custom_timings = new System.Windows.Forms.CheckBox();
             this.gb_arrangement.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nud_y)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nud_x)).BeginInit();
             this.gb_surround.SuspendLayout();
             this.gb_eyefinity.SuspendLayout();
+            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
             // btn_save
@@ -336,7 +339,7 @@ namespace HeliosDisplayManagement.UIForms
             this.gb_surround.Enabled = false;
             this.gb_surround.Location = new System.Drawing.Point(224, 375);
             this.gb_surround.Name = "gb_surround";
-            this.gb_surround.Size = new System.Drawing.Size(207, 184);
+            this.gb_surround.Size = new System.Drawing.Size(207, 67);
             this.gb_surround.TabIndex = 17;
             this.gb_surround.TabStop = false;
             this.gb_surround.Text = "NVidia Surround";
@@ -354,10 +357,11 @@ namespace HeliosDisplayManagement.UIForms
             // 
             // btn_topo
             // 
+            this.btn_topo.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.btn_topo.Enabled = false;
-            this.btn_topo.Location = new System.Drawing.Point(116, 155);
+            this.btn_topo.Location = new System.Drawing.Point(3, 41);
             this.btn_topo.Name = "btn_topo";
-            this.btn_topo.Size = new System.Drawing.Size(85, 23);
+            this.btn_topo.Size = new System.Drawing.Size(201, 23);
             this.btn_topo.TabIndex = 17;
             this.btn_topo.Text = "Edit Topology";
             this.btn_topo.UseVisualStyleBackColor = true;
@@ -392,6 +396,26 @@ namespace HeliosDisplayManagement.UIForms
             this.label5.TabIndex = 18;
             this.label5.Text = resources.GetString("label5.Text");
             // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.cb_custom_timings);
+            this.groupBox1.Location = new System.Drawing.Point(224, 451);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(207, 108);
+            this.groupBox1.TabIndex = 19;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Timings";
+            // 
+            // cb_custom_timings
+            // 
+            this.cb_custom_timings.AutoSize = true;
+            this.cb_custom_timings.Location = new System.Drawing.Point(6, 28);
+            this.cb_custom_timings.Name = "cb_custom_timings";
+            this.cb_custom_timings.Size = new System.Drawing.Size(136, 17);
+            this.cb_custom_timings.TabIndex = 1;
+            this.cb_custom_timings.Text = "Enable Custom Timings";
+            this.cb_custom_timings.UseVisualStyleBackColor = true;
+            // 
             // EditForm
             // 
             this.AcceptButton = this.btn_save;
@@ -399,6 +423,7 @@ namespace HeliosDisplayManagement.UIForms
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btn_cancel;
             this.ClientSize = new System.Drawing.Size(656, 607);
+            this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.gb_eyefinity);
             this.Controls.Add(this.gb_surround);
@@ -426,6 +451,8 @@ namespace HeliosDisplayManagement.UIForms
             this.gb_surround.ResumeLayout(false);
             this.gb_surround.PerformLayout();
             this.gb_eyefinity.ResumeLayout(false);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -461,5 +488,7 @@ namespace HeliosDisplayManagement.UIForms
         private System.Windows.Forms.Label label11;
         private System.Windows.Forms.CheckBox cb_surround_applybezel;
         private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.CheckBox cb_custom_timings;
     }
 }

--- a/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
@@ -74,7 +74,6 @@ namespace HeliosDisplayManagement.UIForms
             // btn_save
             // 
             this.btn_save.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_save.Enabled = false;
             this.btn_save.Location = new System.Drawing.Point(569, 572);
             this.btn_save.Name = "btn_save";
             this.btn_save.Size = new System.Drawing.Size(75, 23);

--- a/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
@@ -408,6 +408,7 @@ namespace HeliosDisplayManagement.UIForms
             // cb_custom_timings
             // 
             this.cb_custom_timings.AutoSize = true;
+            this.cb_custom_timings.Enabled = false;
             this.cb_custom_timings.Location = new System.Drawing.Point(6, 28);
             this.cb_custom_timings.Name = "cb_custom_timings";
             this.cb_custom_timings.Size = new System.Drawing.Size(136, 17);

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -456,7 +456,11 @@ namespace HeliosDisplayManagement.UIForms
 
         private void cb_custom_timings_CheckedChanged(object sender, EventArgs e)
         {
-            CustomTimeEnableChange(cb_custom_timings.Checked);
+            // Accessing private variable explicitly here because the linter wont
+            // let me make this an instance method otherwise
+ 
+            bool toEnable = cb_custom_timings.Checked;
+            CustomTimeEnableChange(toEnable);
         }
 
         private void nud_timing_ValueChanged(object sender, EventArgs e)

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -26,7 +26,7 @@ namespace HeliosDisplayManagement.UIForms
 
             nud_timing.Value = profile.switchTime;
             nud_timing.Minimum = 0;
-            CustomTimeEnableChange(profile.isCustomTimeEnabled);
+            CustomTimeEnableChange(profile.IsCustomTimeEnabled);
 
             RefreshMonitors();
         }
@@ -472,7 +472,7 @@ namespace HeliosDisplayManagement.UIForms
         {
             nud_timing.Enabled = isEnabled;
             time_set_label.Enabled = isEnabled;
-            Profile.isCustomTimeEnabled = isEnabled;
+            Profile.IsCustomTimeEnabled = isEnabled;
             cb_custom_timings.Checked = isEnabled;
         }
     }

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -459,12 +459,19 @@ namespace HeliosDisplayManagement.UIForms
 
         private void cb_custom_timings_CheckedChanged(object sender, EventArgs e)
         {
-            Profile.isCustomTimeEnabled = cb_custom_timings.Checked;
+            CustomTimeEnableChange(cb_custom_timings.Checked);
         }
 
         private void nud_timing_ValueChanged(object sender, EventArgs e)
         {
             Profile.switchTime = (int) nud_timing.Value;
+        }
+
+        private void CustomTimeEnableChange(bool isEnabled) 
+        {
+            nud_timing.Enabled = isEnabled;
+            time_set_label.Enabled = isEnabled;
+            Profile.isCustomTimeEnabled = isEnabled;
         }
     }
 }

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -23,6 +23,14 @@ namespace HeliosDisplayManagement.UIForms
             Text = string.Format(Text, profile.Name);
             txt_name.Text = profile.Name;
             dv_profile.Profile = profile;
+
+            nud_timing.Value = profile.switchTime;
+            nud_timing.Minimum = 0;
+            cb_custom_timings.Checked = profile.isCustomTimeEnabled;
+            nud_timing.Enabled = profile.isCustomTimeEnabled;
+            time_set_label.Enabled = profile.isCustomTimeEnabled;
+
+
             RefreshMonitors();
         }
 

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -461,5 +461,10 @@ namespace HeliosDisplayManagement.UIForms
         {
             Profile.isCustomTimeEnabled = cb_custom_timings.Checked;
         }
+
+        private void nud_timing_ValueChanged(object sender, EventArgs e)
+        {
+            Profile.switchTime = (int) nud_timing.Value;
+        }
     }
 }

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -448,5 +448,10 @@ namespace HeliosDisplayManagement.UIForms
 
             return true;
         }
+
+        private void cb_custom_timings_CheckedChanged(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -26,10 +26,7 @@ namespace HeliosDisplayManagement.UIForms
 
             nud_timing.Value = profile.switchTime;
             nud_timing.Minimum = 0;
-            cb_custom_timings.Checked = profile.isCustomTimeEnabled;
-            nud_timing.Enabled = profile.isCustomTimeEnabled;
-            time_set_label.Enabled = profile.isCustomTimeEnabled;
-
+            CustomTimeEnableChange(profile.isCustomTimeEnabled);
 
             RefreshMonitors();
         }
@@ -472,6 +469,7 @@ namespace HeliosDisplayManagement.UIForms
             nud_timing.Enabled = isEnabled;
             time_set_label.Enabled = isEnabled;
             Profile.isCustomTimeEnabled = isEnabled;
+            cb_custom_timings.Checked = isEnabled;
         }
     }
 }

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -451,7 +451,7 @@ namespace HeliosDisplayManagement.UIForms
 
         private void cb_custom_timings_CheckedChanged(object sender, EventArgs e)
         {
-
+            Profile.isCustomTimeEnabled = cb_custom_timings.Checked;
         }
     }
 }

--- a/HeliosDisplayManagement/UIForms/EditForm.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.cs
@@ -70,7 +70,7 @@ namespace HeliosDisplayManagement.UIForms
                                 failed = true;
                             }
                         }, TaskCreationOptions.LongRunning);
-                    }, 3, 30).ShowDialog(this) !=
+                    }, 3, Profile.switchTime).ShowDialog(this) !=
                     DialogResult.Cancel)
                 {
                     if (failed)
@@ -84,7 +84,7 @@ namespace HeliosDisplayManagement.UIForms
                             () =>
                             {
                                 Task.Factory.StartNew(() => currentProfile.Apply(), TaskCreationOptions.LongRunning);
-                            }, 60, 30) {CancellationMessage = Language.Reverting_in}.ShowDialog(this);
+                            }, 60, Profile.switchTime) {CancellationMessage = Language.Reverting_in}.ShowDialog(this);
                     }
                 }
 

--- a/HeliosDisplayManagement/UIForms/EditForm.resx
+++ b/HeliosDisplayManagement/UIForms/EditForm.resx
@@ -123,6 +123,9 @@
   <data name="label5.Text" xml:space="preserve">
     <value>This tool is not yet complete and this page is currently just a placeholder. Try managing your setup using Windows Control Panel or NVidia Control Panel and use the clone feature to make a new profile.</value>
   </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>32</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/HeliosDisplayManagement/UIForms/MainForm.cs
+++ b/HeliosDisplayManagement/UIForms/MainForm.cs
@@ -64,7 +64,7 @@ namespace HeliosDisplayManagement.UIForms
                         () =>
                         {
                             Task.Factory.StartNew(() => dv_profile.Profile.Apply(), TaskCreationOptions.LongRunning);
-                        }, 3, 30).ShowDialog(this) !=
+                        }, 3, dv_profile.Profile.switchTime).ShowDialog(this) !=
                     DialogResult.Cancel)
                 {
                     ReloadProfiles();

--- a/HeliosDisplayManagement/UIForms/SplashForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/SplashForm.Designer.cs
@@ -77,7 +77,7 @@ namespace HeliosDisplayManagement.UIForms
             this.progressBar.OuterColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
             this.progressBar.OuterMargin = -8;
             this.progressBar.OuterWidth = 6;
-            this.progressBar.ProgressColor = System.Drawing.Color.DodgerBlue;
+            this.progressBar.ProgressColor = System.Drawing.SystemColors.Desktop;
             this.progressBar.ProgressWidth = 10;
             this.progressBar.SecondaryFont = new System.Drawing.Font("Microsoft Sans Serif", 24F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.progressBar.Size = new System.Drawing.Size(135, 135);

--- a/HeliosDisplayManagement/UIForms/SplashForm.cs
+++ b/HeliosDisplayManagement/UIForms/SplashForm.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using System.Diagnostics;
 using HeliosDisplayManagement.Resources;
 using WinFormAnimation;
 
@@ -16,6 +17,8 @@ namespace HeliosDisplayManagement.UIForms
         private int _countdownCounter;
         private bool _isClosing;
         private int _startCounter;
+
+
 
         public SplashForm()
         {
@@ -229,6 +232,41 @@ namespace HeliosDisplayManagement.UIForms
             progressBar.Text = progressBar.Value.ToString();
             _startCounter--;
             Reposition();
+        }
+
+
+        protected override void WndProc(ref Message m)
+        {
+            const int WM_SETTINGCHANGE = 0x001A;
+            const int SPI_SETWORKAREA = 0x02F;
+            const int WM_DISPLAYCHANGE = 0x007E;
+
+            const int x_bitshift = 0;
+            const int y_bitshift = 16;
+            const int xy_mask = 0xFFFF;
+
+            switch (m.Msg)
+            {
+                case WM_SETTINGCHANGE:
+                    Debug.Print("Message: " + m.ToString());
+                    Debug.Print("WM_SETTINGCHANGE");
+                    switch ((int) m.WParam)
+                    {
+                        case SPI_SETWORKAREA:
+                            Debug.Print("SPI_SETWORKAREA");
+                            break;
+                    }
+                    break;
+                case WM_DISPLAYCHANGE:
+                    int cxScreen = (xy_mask & ((int)m.LParam) >> x_bitshift);
+                    int cyScreen = (xy_mask & ((int)m.LParam) >> y_bitshift);
+                    Debug.Print("Message: " + m.ToString());
+                    Debug.Print("WM_DISPLAYCHANGE");
+                    Debug.Print("cxScreen: " + cxScreen  + " cyScreen: " + cyScreen);
+                    break;
+
+            }
+            base.WndProc(ref m);
         }
     }
 }


### PR DESCRIPTION
Related issues:

#19 , #29 

I've gone ahead and implemented the relevant changes to enable this feature. 
Now profile switch timings can be set, and from the "Edit" menu, saving is possible.

Let me know if there's anything that I should change before this PR is ready to merge.

Also, one of us should probably bump the minor version @falahati 