### PR TITLE
Fix : Improve UI responsiveness

### DIFF
--- a/HeliosDisplayManagement/DisplayRepresentation.cs
+++ b/HeliosDisplayManagement/DisplayRepresentation.cs
@@ -24,10 +24,6 @@ namespace HeliosDisplayManagement
 
             IsAvailable = display.IsAvailable;
 
-            if (IsAvailable)
-            {
-                PossibleSettings = GetDisplay()?.GetPossibleSettings()?.ToArray() ?? new DisplayPossibleSetting[0];
-            }
         }
 
         public DisplayRepresentation(PathTarget display)
@@ -36,17 +32,26 @@ namespace HeliosDisplayManagement
             Path = display.DevicePath;
             IsAvailable = GetDisplay()?.IsAvailable ?? false;
 
-            if (IsAvailable)
-            {
-                PossibleSettings = GetDisplay()?.GetPossibleSettings()?.ToArray() ?? new DisplayPossibleSetting[0];
-            }
         }
 
         public bool IsAvailable { get; }
         public string Name { get; }
         public string Path { get; }
 
-        public DisplayPossibleSetting[] PossibleSettings { get; }
+        public DisplayPossibleSetting[] PossibleSettings
+        {
+            get
+            {
+                if (IsAvailable)
+                {
+                    return GetDisplay()?.GetPossibleSettings()?.ToArray() ?? new DisplayPossibleSetting[0];
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
 
         public static IEnumerable<DisplayRepresentation> GetDisplays(Profile profile = null)
         {


### PR DESCRIPTION
Hi ! 

In the direction of the previous pull request, here is a small fix about UI responsiveness. After a few tests it appears that loading all "DisplayPossibleSetting" is the slowest thing happening when refreshing displays, but it's only used occasionally (only for the selected display on the edit form) this little change will load this data "on demand" instead of loading it for each monitor all the time. 
The result will be an UI way more responsive.

Nicolas (Wotever)