### PR TITLE
Fix : Enable "save" and "save and apply"

### DIFF
--- a/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
+++ b/HeliosDisplayManagement/UIForms/EditForm.Designer.cs
@@ -71,7 +71,6 @@ namespace HeliosDisplayManagement.UIForms
             // btn_save
             // 
             this.btn_save.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_save.Enabled = false;
             this.btn_save.Location = new System.Drawing.Point(569, 572);
             this.btn_save.Name = "btn_save";
             this.btn_save.Size = new System.Drawing.Size(75, 23);
@@ -83,7 +82,6 @@ namespace HeliosDisplayManagement.UIForms
             // btn_apply
             // 
             this.btn_apply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btn_apply.Enabled = false;
             this.btn_apply.Location = new System.Drawing.Point(472, 572);
             this.btn_apply.Name = "btn_apply";
             this.btn_apply.Size = new System.Drawing.Size(91, 23);


### PR DESCRIPTION
A little additionnal fix, 
When you added the warning about the development stage of the edit form you disabled the "save" and "save and apply" buttons, making impossible to rename a profile.

This PR simply enable it back